### PR TITLE
Moving `DrawerLayout` into activity, remove from fragment

### DIFF
--- a/app/src/main/java/com/example/backnavigationtestapp/FragmentA.kt
+++ b/app/src/main/java/com/example/backnavigationtestapp/FragmentA.kt
@@ -25,7 +25,7 @@ class FragmentA : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val drawerLayout = view.findViewById<DrawerLayout>(R.id.drawer_layout)
+        val drawerLayout = activity?.findViewById<DrawerLayout>(R.id.drawer_layout)
         val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
         val appBarConfig = AppBarConfiguration(findNavController().graph, drawerLayout)
 
@@ -39,16 +39,15 @@ class FragmentA : Fragment() {
 
         val button2 = view.findViewById<Button>(R.id.button_a2)
         button2.setOnClickListener {
-            drawerLayout.openDrawer(GravityCompat.START)
+            drawerLayout?.openDrawer(GravityCompat.START)
         }
 
-        val drawerNavView = view.findViewById<NavigationView>(R.id.drawer_navigation_view)
-        drawerNavView.setNavigationItemSelectedListener { _ ->
+        val drawerNavView = activity?.findViewById<NavigationView>(R.id.drawer_navigation_view)
+        drawerNavView?.setNavigationItemSelectedListener { _ ->
             val action = FragmentADirections.actionFragmentAToFragmentC()
             findNavController().navigate(action)
 
-            drawerLayout.closeDrawer(GravityCompat.START)
-
+            drawerLayout?.closeDrawer(GravityCompat.START)
             true
         }
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:openDrawer="start">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/nav_host_fragment"
@@ -14,4 +15,10 @@
         app:defaultNavHost="true"
         app:navGraph="@navigation/nav_graph" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <com.google.android.material.navigation.NavigationView
+        android:id="@+id/drawer_navigation_view"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        app:menu="@menu/drawer_menu" />
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/fragment_a.xml
+++ b/app/src/main/res/layout/fragment_a.xml
@@ -1,51 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:openDrawer="start">
+    android:background="@android:color/holo_blue_dark"
+    tools:context=".FragmentA">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@android:color/holo_blue_dark"
-        tools:context=".FragmentA">
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <Button
-            android:id="@+id/button_a1"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Go to Fragment B"
-            app:layout_constraintBottom_toTopOf="@id/button_a2"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <Button
-            android:id="@+id/button_a2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Open Drawer Layout"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/button_a1" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/drawer_navigation_view"
+    <Button
+        android:id="@+id/button_a1"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        app:menu="@menu/drawer_menu" />
-</androidx.drawerlayout.widget.DrawerLayout>
+        android:layout_height="wrap_content"
+        android:text="Go to Fragment B"
+        app:layout_constraintBottom_toTopOf="@id/button_a2"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
+    <Button
+        android:id="@+id/button_a2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Open Drawer Layout"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button_a1" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Moving the drawer layout into the activity class (and not in Fragment A).

This fixes the navigation bug, as the drawer layout does not get destroyed/view is removed - which I believe is the root cause of the bug itself.